### PR TITLE
Add Github private repo switch

### DIFF
--- a/src/data/detectors.json
+++ b/src/data/detectors.json
@@ -170,6 +170,12 @@
         "request_url": "https://api.github.com/user/repos?per_page=100&page=1",
         "request_method": "GET"
       },
+      "private-repos": {
+        "label": "Private Repos",
+        "curl": "curl -X GET 'https://api.github.com/user/repos?visibility=private&per_page=100&page=1' -H 'Authorization: token <access_token>'",
+        "request_url": "https://api.github.com/user/repos?visibility=private&per_page=100&page=1",
+        "request_method": "GET"
+      },
       "organizations": {
         "label": "Organizations",
         "curl": "curl -X GET 'https://api.github.com/user/orgs' -H 'Authorization: token <access_token>'",


### PR DESCRIPTION
Implemented a new switch in the GitHub Detectors to enable filtering of private repositories only.